### PR TITLE
Minor enhancements and fixes to OTP auth flow

### DIFF
--- a/app/controllers/web/my-account.js
+++ b/app/controllers/web/my-account.js
@@ -122,9 +122,9 @@ async function setup2fa(ctx) {
       return ctx.throw(Boom.badRequest(ctx.translate('INVALID_OTP_PASSCODE')));
 
     // generate 2fa recovery keys list used for fallback
-    const recoveryKeys = new Array(16).map(() =>
-      cryptoRandomString({ length: 10, characters: '1234567890' })
-    );
+    const recoveryKeys = new Array(16)
+      .fill()
+      .map(() => cryptoRandomString({ length: 10, characters: '1234567890' }));
 
     ctx.state.user[config.userFields.twoFactorRecoveryKeys] = recoveryKeys;
     ctx.state.user[config.userFields.twoFactorEnabled] = true;

--- a/app/views/my-account/2fa-recovery.pug
+++ b/app/views/my-account/2fa-recovery.pug
@@ -8,7 +8,7 @@ block body
         .card
           .card-body
             .text-center
-              h1.card-title.h4= t('Two-Factory Authentication Recovery')
+              h1.card-title.h4= t('Two-Factor Authentication Recovery')
               p= t('Please enter a two-factor recovery key to login.')
             form(action=`${ctx.locale}/2fa-recovery`, method="POST", autocomplete="off").ajax-form
               input(type="hidden", name="_csrf", value=ctx.csrf)

--- a/app/views/my-account/security.pug
+++ b/app/views/my-account/security.pug
@@ -23,14 +23,6 @@ block body
                     i.fa.fa-clipboard
                     = ' '
                     = t('Copy')
-              .input-group.input-group-sm.floating-label.form-group
-                input(type='text', readonly, value=twoFactorTokenURI).form-control#two-factor-token-uri
-                label(for='two-factor-token-uri')= t('Two-Factor Token URI')
-                .input-group-append
-                  button(type='button', data-toggle="clipboard", data-clipboard-target="#two-factor-token-uri").btn.btn-primary
-                    i.fa.fa-clipboard
-                    = ' '
-                    = t('Copy')
               hr
               p.lead.text-center.font-weight-bold= t('Enter the token generated from your app below:')
               .form-group.floating-label
@@ -47,7 +39,7 @@ block body
             h4.card-header= t('Two-Factor Authentication')
             .card-body
               if user[config.userFields.twoFactorEnabled]
-                h3= t('Recovery keys')
+                h5= t('Recovery keys')
                 p= t('Recovery keys allow you to login to your account when you have lost access to your Two-Factor Authentication device or authenticator app.  Download your recovery keys and put them in a safe place to use as a last resort.')
                 form(action=l('/my-account/recovery-keys'), method='POST')
                   input(type="hidden", name="_csrf", value=ctx.csrf)

--- a/app/views/my-account/security.pug
+++ b/app/views/my-account/security.pug
@@ -42,21 +42,22 @@ block body
     .row.mt-1
       .col
         include ../_breadcrumbs
-        .card.card-bg-light.mb-3
-          h4.card-header= t('Two-Factor Authentication')
-          .card-body
-            if user[config.userFields.twoFactorEnabled]
-              h3= t('Recovery keys')
-              p= t('Recovery keys allow you to login to your account when you have lost access to your Two-Factor Authentication device or authenticator app.  Download your recovery keys and put them in a safe place to use as a last resort.')
-              form(action=l('/my-account/recovery-keys'), method='POST')
-                input(type="hidden", name="_csrf", value=ctx.csrf)
-                button(type='submit').btn.btn-secondary.btn-lg= t('Download recovery keys')
-              form(action=l('/my-account/setup-2fa'), method='POST').ajax-form.confirm-prompt.mt-3
-                input(type='hidden', name='_method', value='DELETE')
-                input(type="hidden", name="_csrf", value=ctx.csrf)
-                button(Type='submit').btn.btn-danger.btn-lg= t('Disable Two-Factor Authentication')
-            else
-              button(data-toggle='modal', data-target='#modal-enable-2fa', type='button').btn.btn-primary.btn-lg= t('Enable Two-Factor Authentication')
+        if boolean(process.env.AUTH_OTP_ENABLED)
+          .card.card-bg-light.mb-3
+            h4.card-header= t('Two-Factor Authentication')
+            .card-body
+              if user[config.userFields.twoFactorEnabled]
+                h3= t('Recovery keys')
+                p= t('Recovery keys allow you to login to your account when you have lost access to your Two-Factor Authentication device or authenticator app.  Download your recovery keys and put them in a safe place to use as a last resort.')
+                form(action=l('/my-account/recovery-keys'), method='POST')
+                  input(type="hidden", name="_csrf", value=ctx.csrf)
+                  button(type='submit').btn.btn-secondary.btn-lg= t('Download recovery keys')
+                form(action=l('/my-account/setup-2fa'), method='POST').ajax-form.confirm-prompt.mt-3
+                  input(type='hidden', name='_method', value='DELETE')
+                  input(type="hidden", name="_csrf", value=ctx.csrf)
+                  button(Type='submit').btn.btn-danger.btn-lg= t('Disable Two-Factor Authentication')
+              else
+                button(data-toggle='modal', data-target='#modal-enable-2fa', type='button').btn.btn-primary.btn-lg= t('Enable Two-Factor Authentication')
         .card.card-bg-light
           h4.card-header= t('API Credentials')
           .card-body


### PR DESCRIPTION
- typo in recovery key title
- remove 2fa section from security page if OTP disabled (shouldn't be able to try and enable 2fa)
- touch up recovery key font
- fix recovery key list generation (previously empty)